### PR TITLE
Set default repo to amit-sw/gitowner

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -12,8 +12,8 @@ from report_generator import (
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
-DEFAULT_REPO_OWNER = "deepchem"
-DEFAULT_REPO_NAME = "deepchem"
+DEFAULT_REPO_OWNER = "amit-sw"
+DEFAULT_REPO_NAME = "gitowner"
 DEFAULT_COMMIT_COUNT = 2000
 
 DEFAULT_PROMPT = """


### PR DESCRIPTION
## Summary
- default to `amit-sw` for the account
- default to `gitowner` for the repository

## Testing
- `python -m py_compile streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_6845cdce72148332bab546b3b671b002